### PR TITLE
Fix health check path

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -161,7 +161,7 @@ health_check() {
     local attempt=1
     
     while [ $attempt -le $max_attempts ]; do
-        if curl -f -s http://localhost:3000/health > /dev/null; then
+        if curl -f -s http://localhost:3000/api/health > /dev/null; then
             log_success "API сервис работает"
             break
         fi


### PR DESCRIPTION
## Summary
- correct health check endpoint in `deploy.sh`

## Testing
- `node test-fetch.js` *(fails: fetch failed)*
- `node test-polyfill-logic.js`
- `./deploy.sh deploy`

------
https://chatgpt.com/codex/tasks/task_e_6876be618c14832c95939892d96689f9