### PR TITLE
Move xui dashboard to account and add server editor

### DIFF
--- a/backend/routes/xuiRouter.js
+++ b/backend/routes/xuiRouter.js
@@ -2,20 +2,61 @@ const express = require('express');
 const { getInbounds } = require('../xuiService');
 const router = express.Router();
 
-let XUI_CONFIG, cookieCache, logger;
+let cookieCache, logger;
+let servers = [];
 
 function initXuiRouter(deps) {
-  XUI_CONFIG = deps.XUI_CONFIG;
+  const cfg = deps.XUI_CONFIG;
   cookieCache = deps.cookieCache;
   logger = deps.logger;
+  servers = [
+    {
+      id: Date.now(),
+      name: cfg.name || 'Default',
+      baseUrl: cfg.baseUrl,
+      username: cfg.username,
+      password: cfg.password
+    }
+  ];
 }
 
-router.get('/xui/inbounds', async (req, res) => {
+router.get('/xui/servers', (req, res) => {
+  res.json({ servers });
+});
+
+router.post('/xui/servers', (req, res) => {
+  const { name, baseUrl, username, password } = req.body || {};
+  if (!name || !baseUrl || !username || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  const id = Date.now();
+  servers.push({ id, name, baseUrl, username, password });
+  res.status(201).json({ id });
+});
+
+router.delete('/xui/servers/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const idx = servers.findIndex(s => s.id === id);
+  if (idx === -1) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+  servers.splice(idx, 1);
+  res.status(204).end();
+});
+
+router.get('/xui/inbounds/:id', async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const server = servers.find(s => s.id === id);
+  if (!server) {
+    return res.status(404).json({ error: 'Server not found' });
+  }
   try {
-    const inbounds = await getInbounds(XUI_CONFIG, cookieCache, logger);
+    const inbounds = await getInbounds(server, cookieCache, logger);
     res.json({ inbounds });
   } catch (error) {
-    logger && logger.error && logger.error('Failed to get xui inbounds', { error: error.message });
+    logger &&
+      logger.error &&
+      logger.error('Failed to get xui inbounds', { error: error.message });
     res.status(500).json({ error: 'Failed to fetch xui inbounds' });
   }
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,9 +4,18 @@ const cors = require('cors');
 const fs = require('fs');
 const path = require('path');
 require('dotenv').config({ path: path.join(__dirname, '.env') });
-const { router: statusRouter, initStatusRouter } = require('./routes/statusRouter');
-const { router: healthRouter, initHealthRouter } = require('./routes/healthRouter');
-const { router: cacheRouter, initCacheRouter } = require('./routes/cacheRouter');
+const {
+  router: statusRouter,
+  initStatusRouter
+} = require('./routes/statusRouter');
+const {
+  router: healthRouter,
+  initHealthRouter
+} = require('./routes/healthRouter');
+const {
+  router: cacheRouter,
+  initCacheRouter
+} = require('./routes/cacheRouter');
 const { router: xuiRouter, initXuiRouter } = require('./routes/xuiRouter');
 const { validateOptionalVars } = require('./config/validation');
 const { createLogger } = require('./config/logger');
@@ -18,18 +27,22 @@ const { getServerConfigs } = require('./config/serverConfigs');
 const { StatusCache, CookieCache } = require('./utils/cache');
 const { errorHandler } = require('./middleware/errorHandler');
 
-
 // --- СОЗДАНИЕ ДИРЕКТОРИИ ДЛЯ ЛОГОВ ---
 const logsDir = path.join(__dirname, 'logs');
 if (!fs.existsSync(logsDir)) {
-    fs.mkdirSync(logsDir, { recursive: true });
+  fs.mkdirSync(logsDir, { recursive: true });
 }
 
 // --- НАСТРОЙКА ЛОГИРОВАНИЯ ---
 // Для fetch-полифилла logger нужен уже здесь, поэтому создаём с дефолтными значениями
 const defaultLogLevel = process.env.LOG_LEVEL || 'info';
 const defaultNodeEnv = process.env.NODE_ENV || 'development';
-const logger = createLogger(logsDir, defaultLogLevel, defaultNodeEnv, 'backend');
+const logger = createLogger(
+  logsDir,
+  defaultLogLevel,
+  defaultNodeEnv,
+  'backend'
+);
 
 // --- ПОЛИФИЛЛ ДЛЯ FETCH ---
 // Проверяем версию Node.js и добавляем полифилл если нужно
@@ -37,12 +50,14 @@ const nodeVersion = process.version;
 const majorVersion = parseInt(nodeVersion.slice(1).split('.')[0], 10);
 
 if (majorVersion < 18) {
-    // Для Node.js < 18 используем node-fetch как полифилл
-    const fetch = require('node-fetch');
-    global.fetch = fetch;
-    logger.info(`Node.js ${nodeVersion} detected, using node-fetch polyfill for fetch API`);
+  // Для Node.js < 18 используем node-fetch как полифилл
+  const fetch = require('node-fetch');
+  global.fetch = fetch;
+  logger.info(
+    `Node.js ${nodeVersion} detected, using node-fetch polyfill for fetch API`
+  );
 } else {
-    logger.info(`Node.js ${nodeVersion} detected, using native fetch API`);
+  logger.info(`Node.js ${nodeVersion} detected, using native fetch API`);
 }
 
 const app = express();
@@ -55,25 +70,34 @@ let optionalVars;
 let SERVER_CONFIGS;
 
 try {
-    logger.info('Starting environment variables validation...');
-    
-    // Валидируем опциональные переменные и конфигурацию серверов
-    optionalVars = validateOptionalVars();
-    SERVER_CONFIGS = getServerConfigs();
-    
-    logger.info('Environment variables validation completed successfully');
-    
+  logger.info('Starting environment variables validation...');
+
+  // Валидируем опциональные переменные и конфигурацию серверов
+  optionalVars = validateOptionalVars();
+  SERVER_CONFIGS = getServerConfigs();
+
+  logger.info('Environment variables validation completed successfully');
 } catch (error) {
-    logger.error('Environment variables validation failed:', { error: error.message });
-    throw new Error(`Environment variables validation failed: ${  error.message}`);
+  logger.error('Environment variables validation failed:', {
+    error: error.message
+  });
+  throw new Error(`Environment variables validation failed: ${error.message}`);
 }
 
 const port = optionalVars.PORT;
 
 // --- КОНФИГУРАЦИЯ СЕРВЕРОВ ---
 // --- КЭШИРОВАНИЕ И СОСТОЯНИЕ ---
-const statusCache = new StatusCache(process.env.CACHE_DURATION ? parseInt(process.env.CACHE_DURATION, 10) : 60 * 1000);
-const cookieCache = new CookieCache(process.env.COOKIE_CACHE_DURATION ? parseInt(process.env.COOKIE_CACHE_DURATION, 10) : 55 * 60 * 1000);
+const statusCache = new StatusCache(
+  process.env.CACHE_DURATION
+    ? parseInt(process.env.CACHE_DURATION, 10)
+    : 60 * 1000
+);
+const cookieCache = new CookieCache(
+  process.env.COOKIE_CACHE_DURATION
+    ? parseInt(process.env.COOKIE_CACHE_DURATION, 10)
+    : 55 * 60 * 1000
+);
 
 // --- MIDDLEWARE ---
 app.set('trust proxy', 1);
@@ -103,6 +127,7 @@ initCacheRouter({
 });
 initXuiRouter({
   XUI_CONFIG: {
+    name: 'Default',
     baseUrl: process.env.XUI_BASE_URL,
     username: process.env.XUI_USERNAME,
     password: process.env.XUI_PASSWORD
@@ -117,29 +142,34 @@ app.use('/api', cacheRouter);
 app.use('/api', xuiRouter);
 
 // --- FRONTEND LOGGING ENDPOINT ---
-const frontendLogger = createLogger(logsDir, optionalVars.LOG_LEVEL, optionalVars.NODE_ENV, 'frontend');
+const frontendLogger = createLogger(
+  logsDir,
+  optionalVars.LOG_LEVEL,
+  optionalVars.NODE_ENV,
+  'frontend'
+);
 app.post('/api/log', express.json({ limit: '100kb' }), (req, res) => {
-    const { level = 'info', message, ...meta } = req.body || {};
-    if (typeof frontendLogger[level] === 'function') {
-        frontendLogger[level](message, meta);
-    } else {
-        frontendLogger.info(message, meta);
-    }
-    res.status(204).end();
+  const { level = 'info', message, ...meta } = req.body || {};
+  if (typeof frontendLogger[level] === 'function') {
+    frontendLogger[level](message, meta);
+  } else {
+    frontendLogger.info(message, meta);
+  }
+  res.status(204).end();
 });
 
 // --- СТАТИКА и SPA fallback ---
 app.use(express.static(path.join(__dirname, '..', 'frontend', 'dist')));
 app.get('*', (req, res) => {
-    if (req.method === 'GET' && !req.path.startsWith('/api')) {
-        logger.debug(`SPA fallback for path: ${req.path}`);
-        res.sendFile(path.join(__dirname, '..', 'frontend', 'dist', 'index.html'));
-    } else {
+  if (req.method === 'GET' && !req.path.startsWith('/api')) {
+    logger.debug(`SPA fallback for path: ${req.path}`);
+    res.sendFile(path.join(__dirname, '..', 'frontend', 'dist', 'index.html'));
+  } else {
     res.status(404).json({
-        error: 'Not Found',
-        message: 'The requested endpoint does not exist'
+      error: 'Not Found',
+      message: 'The requested endpoint does not exist'
     });
-    }
+  }
 });
 
 // --- ГЛОБАЛЬНЫЙ ОБРАБОТЧИК ОШИБОК ---
@@ -147,19 +177,19 @@ app.use(errorHandler(logger));
 
 // --- ЗАПУСК СЕРВЕРА ---
 const server = app.listen(port, () => {
-    logger.info(`ROX VPN API server started on port ${port}`, {
-        port,
-        environment: process.env.NODE_ENV || 'development',
-        serversConfigured: SERVER_CONFIGS.length
-    });
+  logger.info(`ROX VPN API server started on port ${port}`, {
+    port,
+    environment: process.env.NODE_ENV || 'development',
+    serversConfigured: SERVER_CONFIGS.length
+  });
 });
 
 // --- GRACEFUL SHUTDOWN ---
 setupGracefulShutdown(server, logger);
 
 // Логируем остановку сервера
-process.on('exit', (code) => {
-    logger.info('Process exit', { code });
+process.on('exit', code => {
+  logger.info('Process exit', { code });
 });
 
 module.exports = app;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,27 +1,29 @@
-import React from 'react';
-import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom';
-import { HelmetProvider } from 'react-helmet-async';
-import Header from './components/Header';
-import Footer from './components/Footer';
-import Home from './pages/Home';
-import Servers from './pages/Servers';
-import Faq from './pages/Faq';
-import Account from './pages/Account';
-import ProfilePage from './pages/ProfilePage';
-import MyDataPage from './pages/MyDataPage';
-import SupportPage from './pages/SupportPage';
-import NotificationsPage from './pages/NotificationsPage';
-import XuiDashboard from './pages/XuiDashboard';
-import TelegramFab from './components/TelegramFab';
-import { logFrontend } from './utils/logger';
-import { ThemeProvider } from './context/ThemeContext';
-import { UserProvider } from './context/UserContext';
-import { AccountProvider } from './context/AccountContext';
+import React from "react";
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  useLocation,
+} from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
+import Home from "./pages/Home";
+import Servers from "./pages/Servers";
+import Faq from "./pages/Faq";
+import Account from "./pages/Account";
+import ProfilePage from "./pages/ProfilePage";
+import XuiDashboard from "./pages/XuiDashboard";
+import TelegramFab from "./components/TelegramFab";
+import { logFrontend } from "./utils/logger";
+import { ThemeProvider } from "./context/ThemeContext";
+import { UserProvider } from "./context/UserContext";
+import { AccountProvider } from "./context/AccountContext";
 
 function ScrollToTop() {
   const { pathname } = useLocation();
   React.useEffect(() => {
-    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
   }, [pathname]);
   return null;
 }
@@ -29,7 +31,10 @@ function ScrollToTop() {
 function RouteLogger() {
   const { pathname } = useLocation();
   React.useEffect(() => {
-    logFrontend('info', 'User navigated', { path: pathname, ts: new Date().toISOString() });
+    logFrontend("info", "User navigated", {
+      path: pathname,
+      ts: new Date().toISOString(),
+    });
   }, [pathname]);
   return null;
 }
@@ -40,31 +45,28 @@ const App: React.FC = () => (
       <UserProvider>
         <AccountProvider>
           <Router>
-          <ScrollToTop />
-          <RouteLogger />
-          <Header />
-          <main className="flex-1 pt-16 lg:pt-20">
-            <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/servers" element={<Servers />} />
-              <Route path="/xui" element={<XuiDashboard />} />
-              <Route path="/faq" element={<Faq />} />
-            <Route path="/account" element={<Account />}>
-              <Route index element={<ProfilePage />} />
-              <Route path="profile" element={<ProfilePage />} />
-              <Route path="data" element={<MyDataPage />} />
-              <Route path="support" element={<SupportPage />} />
-              <Route path="notifications" element={<NotificationsPage />} />
-            </Route>
-            </Routes>
-            <TelegramFab />
-          </main>
-          <Footer />
-        </Router>
+            <ScrollToTop />
+            <RouteLogger />
+            <Header />
+            <main className="flex-1 pt-16 lg:pt-20">
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/servers" element={<Servers />} />
+                <Route path="/faq" element={<Faq />} />
+                <Route path="/account" element={<Account />}>
+                  <Route index element={<ProfilePage />} />
+                  <Route path="profile" element={<ProfilePage />} />
+                  <Route path="xui" element={<XuiDashboard />} />
+                </Route>
+              </Routes>
+              <TelegramFab />
+            </main>
+            <Footer />
+          </Router>
         </AccountProvider>
       </UserProvider>
     </ThemeProvider>
   </HelmetProvider>
 );
 
-export default App; 
+export default App;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,22 +1,22 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import {
   FaHome,
   FaServer,
   FaQuestionCircle,
   FaTelegramPlane,
   FaUser,
-  FaCogs
-} from 'react-icons/fa';
-import { NavLink } from 'react-router-dom';
-import { useTheme } from '../context/ThemeContext';
-import { SunIcon, MoonIcon } from '@heroicons/react/24/outline';
-import { useUser } from '../context/UserContext';
+  FaCogs,
+} from "react-icons/fa";
+import { NavLink } from "react-router-dom";
+import { useTheme } from "../context/ThemeContext";
+import { SunIcon, MoonIcon } from "@heroicons/react/24/outline";
+import { useUser } from "../context/UserContext";
 
 function getInitialDark() {
-  if (typeof window !== 'undefined') {
-    const saved = localStorage.getItem('theme');
-    if (saved) return saved === 'dark';
-    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (typeof window !== "undefined") {
+    const saved = localStorage.getItem("theme");
+    if (saved) return saved === "dark";
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   return false;
 }
@@ -27,11 +27,31 @@ const Header: React.FC = () => {
   const { username } = useUser();
   const links = useMemo(
     () => [
-      { href: '/', label: 'Главная', icon: <FaHome />, ariaLabel: 'Главная' },
-      { href: '/servers', label: 'Серверы', icon: <FaServer />, ariaLabel: 'Серверы' },
-      { href: '/xui', label: '3x-ui', icon: <FaCogs />, ariaLabel: '3x-ui' },
-      { href: '/faq', label: 'FAQ', icon: <FaQuestionCircle />, ariaLabel: 'FAQ' },
-      { href: '/account', label: username || 'Аккаунт', icon: <FaUser />, ariaLabel: 'Аккаунт' },
+      { href: "/", label: "Главная", icon: <FaHome />, ariaLabel: "Главная" },
+      {
+        href: "/servers",
+        label: "Серверы",
+        icon: <FaServer />,
+        ariaLabel: "Серверы",
+      },
+      {
+        href: "/account/xui",
+        label: "3x-ui",
+        icon: <FaCogs />,
+        ariaLabel: "3x-ui",
+      },
+      {
+        href: "/faq",
+        label: "FAQ",
+        icon: <FaQuestionCircle />,
+        ariaLabel: "FAQ",
+      },
+      {
+        href: "/account",
+        label: username || "Аккаунт",
+        icon: <FaUser />,
+        ariaLabel: "Аккаунт",
+      },
     ],
     [username],
   );
@@ -52,19 +72,19 @@ const Header: React.FC = () => {
   useEffect(() => {
     const handleScroll = () => {
       const currentScrollY = window.scrollY;
-      
+
       // Скрываем хедер при скролле вниз, показываем при скролле вверх
       if (currentScrollY > lastScrollY && currentScrollY > 100) {
         setIsHeaderHidden(true);
       } else if (currentScrollY < lastScrollY) {
         setIsHeaderHidden(false);
       }
-      
+
       setLastScrollY(currentScrollY);
     };
 
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    return () => window.removeEventListener('scroll', handleScroll);
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
   }, [lastScrollY]);
 
   // Фокусировка на первом пункте мобильного меню при открытии
@@ -77,35 +97,47 @@ const Header: React.FC = () => {
   const navLinkClass = ({ isActive }: { isActive: boolean }) =>
     `flex items-center gap-2 px-4 py-2 rounded-xl font-semibold transition-all duration-200 shadow-sm focus:outline-none focus:ring-2 focus:ring-accent/60 ` +
     (isActive
-      ? 'bg-gradient-to-r from-green-200/80 to-blue-200/80 dark:from-blue-900/60 dark:to-green-900/60 text-accent'
-      : 'text-gray-700 dark:text-gray-200 hover:bg-gradient-to-r hover:from-green-100/80 hover:to-blue-100/80 dark:hover:from-blue-900/60 dark:hover:to-green-900/60 hover:text-accent');
+      ? "bg-gradient-to-r from-green-200/80 to-blue-200/80 dark:from-blue-900/60 dark:to-green-900/60 text-accent"
+      : "text-gray-700 dark:text-gray-200 hover:bg-gradient-to-r hover:from-green-100/80 hover:to-blue-100/80 dark:hover:from-blue-900/60 dark:hover:to-green-900/60 hover:text-accent");
 
   const mobileNavLinkClass = ({ isActive }: { isActive: boolean }) =>
     `flex items-center gap-3 text-lg px-4 py-3 rounded-xl font-semibold transition-all duration-200 shadow-sm ` +
     (isActive
-      ? 'bg-gradient-to-r from-green-200/80 to-blue-200/80 dark:from-blue-900/60 dark:to-green-900/60 text-accent'
-      : 'text-gray-700 dark:text-gray-200 hover:bg-gradient-to-r hover:from-green-100/80 hover:to-blue-100/80 dark:hover:from-blue-900/60 dark:hover:to-green-900/60 hover:text-accent');
+      ? "bg-gradient-to-r from-green-200/80 to-blue-200/80 dark:from-blue-900/60 dark:to-green-900/60 text-accent"
+      : "text-gray-700 dark:text-gray-200 hover:bg-gradient-to-r hover:from-green-100/80 hover:to-blue-100/80 dark:hover:from-blue-900/60 dark:hover:to-green-900/60 hover:text-accent");
 
   return (
-    <header className={`w-full bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl border-b border-gray-200/50 dark:border-gray-700/50 fixed top-0 left-0 right-0 z-50 shadow-lg transition-all duration-300 ${isHeaderHidden ? '-translate-y-full' : 'translate-y-0'}`}>
+    <header
+      className={`w-full bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl border-b border-gray-200/50 dark:border-gray-700/50 fixed top-0 left-0 right-0 z-50 shadow-lg transition-all duration-300 ${isHeaderHidden ? "-translate-y-full" : "translate-y-0"}`}
+    >
       <div className="container mx-auto px-4 flex items-center justify-between h-16 lg:h-20">
         {/* Логотип */}
         <NavLink to="/" className="flex items-center space-x-3 group">
           <div className="w-10 h-10 bg-gradient-to-br from-green-400 via-blue-400 to-blue-600 rounded-2xl flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform">
-            <span className="text-white font-black text-lg drop-shadow-lg">R</span>
+            <span className="text-white font-black text-lg drop-shadow-lg">
+              R
+            </span>
           </div>
-          <span className="text-2xl font-extrabold bg-gradient-to-r from-green-600 via-blue-500 to-blue-700 bg-clip-text text-transparent tracking-tight group-hover:drop-shadow-lg transition-all">ROX.VPN</span>
+          <span className="text-2xl font-extrabold bg-gradient-to-r from-green-600 via-blue-500 to-blue-700 bg-clip-text text-transparent tracking-tight group-hover:drop-shadow-lg transition-all">
+            ROX.VPN
+          </span>
         </NavLink>
         {/* Навигация (десктоп) */}
         <nav className="hidden lg:flex items-center space-x-2 xl:space-x-4">
-          {links.map(link => (
+          {links.map((link) => (
             <NavLink
               key={link.href}
               to={link.href}
               className={navLinkClass}
-              end={link.href === '/'}
+              end={link.href === "/"}
             >
-              <span className="text-lg opacity-80" aria-label={link.ariaLabel} title={link.ariaLabel}>{link.icon}</span>
+              <span
+                className="text-lg opacity-80"
+                aria-label={link.ariaLabel}
+                title={link.ariaLabel}
+              >
+                {link.icon}
+              </span>
               <span>{link.label}</span>
             </NavLink>
           ))}
@@ -115,7 +147,10 @@ const Header: React.FC = () => {
           {/* Переключатель темы */}
           <div className="relative">
             <button
-              onClick={() => { toggleTheme(); setPop(true); }}
+              onClick={() => {
+                toggleTheme();
+                setPop(true);
+              }}
               onMouseEnter={() => setShowTooltip(true)}
               onMouseLeave={() => setShowTooltip(false)}
               onFocus={() => setShowTooltip(true)}
@@ -124,7 +159,9 @@ const Header: React.FC = () => {
               aria-label="Переключить тёмный режим"
               type="button"
             >
-              <span className={`inline-block transition-transform duration-150 ${pop ? 'scale-125' : 'scale-100'}`}>
+              <span
+                className={`inline-block transition-transform duration-150 ${pop ? "scale-125" : "scale-100"}`}
+              >
                 {dark ? (
                   <SunIcon className="w-6 h-6 text-yellow-400 transition-colors duration-300" />
                 ) : (
@@ -134,7 +171,7 @@ const Header: React.FC = () => {
             </button>
             {showTooltip && (
               <span className="absolute left-1/2 -translate-x-1/2 mt-2 px-3 py-1 rounded bg-gray-900 text-white text-xs shadow-lg z-50 whitespace-nowrap select-none pointer-events-none animate-fade-in">
-                {dark ? 'Светлая тема' : 'Тёмная тема'}
+                {dark ? "Светлая тема" : "Тёмная тема"}
               </span>
             )}
           </div>
@@ -152,13 +189,19 @@ const Header: React.FC = () => {
           {/* Мобильное меню */}
           <button
             className="lg:hidden p-2 rounded-xl bg-white/60 dark:bg-gray-800/60 hover:bg-accent/20 dark:hover:bg-accent/20 transition-colors shadow"
-            aria-label={menuOpen ? 'Закрыть меню' : 'Открыть меню'}
-            onClick={() => setMenuOpen(m => !m)}
+            aria-label={menuOpen ? "Закрыть меню" : "Открыть меню"}
+            onClick={() => setMenuOpen((m) => !m)}
           >
             <div className="w-7 h-7 relative">
-              <span className={`absolute left-0 w-7 h-0.5 bg-current transform transition-all duration-300 ${menuOpen ? 'rotate-45 translate-y-0' : '-translate-y-2'}`} />
-              <span className={`absolute left-0 w-7 h-0.5 bg-current transform transition-all duration-300 ${menuOpen ? 'opacity-0' : 'opacity-100'}`} />
-              <span className={`absolute left-0 w-7 h-0.5 bg-current transform transition-all duration-300 ${menuOpen ? '-rotate-45 translate-y-0' : 'translate-y-2'}`} />
+              <span
+                className={`absolute left-0 w-7 h-0.5 bg-current transform transition-all duration-300 ${menuOpen ? "rotate-45 translate-y-0" : "-translate-y-2"}`}
+              />
+              <span
+                className={`absolute left-0 w-7 h-0.5 bg-current transform transition-all duration-300 ${menuOpen ? "opacity-0" : "opacity-100"}`}
+              />
+              <span
+                className={`absolute left-0 w-7 h-0.5 bg-current transform transition-all duration-300 ${menuOpen ? "-rotate-45 translate-y-0" : "translate-y-2"}`}
+              />
             </div>
           </button>
         </div>
@@ -175,7 +218,9 @@ const Header: React.FC = () => {
           {/* Мобильное меню с анимацией */}
           <div
             className="lg:hidden fixed top-0 left-0 right-0 z-50 transform transition-transform duration-300"
-            style={{ transform: menuOpen ? 'translateY(0)' : 'translateY(-100%)' }}
+            style={{
+              transform: menuOpen ? "translateY(0)" : "translateY(-100%)",
+            }}
           >
             <div className="bg-white/95 dark:bg-gray-900/95 border-t border-gray-200 dark:border-gray-700 shadow-2xl rounded-b-3xl">
               <div className="container mx-auto px-4 py-6">
@@ -185,11 +230,17 @@ const Header: React.FC = () => {
                       key={link.href}
                       to={link.href}
                       className={mobileNavLinkClass}
-                      end={link.href === '/'}
+                      end={link.href === "/"}
                       onClick={() => setMenuOpen(false)}
                       ref={idx === 0 ? firstMobileLinkRef : undefined}
                     >
-                      <span className="text-xl opacity-80" aria-label={link.ariaLabel} title={link.ariaLabel}>{link.icon}</span>
+                      <span
+                        className="text-xl opacity-80"
+                        aria-label={link.ariaLabel}
+                        title={link.ariaLabel}
+                      >
+                        {link.icon}
+                      </span>
                       <span>{link.label}</span>
                     </NavLink>
                   ))}
@@ -212,4 +263,4 @@ const Header: React.FC = () => {
   );
 };
 
-export default Header; 
+export default Header;

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
-import { NavLink, Outlet } from 'react-router-dom';
-import PageHead from '../components/PageHead';
-import { useAccount } from '../context/AccountContext';
-import { useUser } from '../context/UserContext';
+import React from "react";
+import { NavLink, Outlet } from "react-router-dom";
+import PageHead from "../components/PageHead";
+import { useAccount } from "../context/AccountContext";
+import { useUser } from "../context/UserContext";
 
 const linkClass = ({ isActive }: { isActive: boolean }) =>
   `px-4 py-2 rounded-md text-center transition-colors ${
-    isActive ? 'bg-blue-600 text-white' : 'bg-blue-100 text-blue-800 hover:bg-blue-200'
+    isActive
+      ? "bg-blue-600 text-white"
+      : "bg-blue-100 text-blue-800 hover:bg-blue-200"
   }`;
 
 const Account: React.FC = () => {
@@ -15,18 +17,28 @@ const Account: React.FC = () => {
 
   return (
     <>
-      <PageHead title="Личный кабинет" description="Управление аккаунтом" path="/account" />
+      <PageHead
+        title="Личный кабинет"
+        description="Управление аккаунтом"
+        path="/account"
+      />
       <div className="container mx-auto p-4 max-w-2xl space-y-6">
         <h1 className="text-2xl font-bold">Личный кабинет</h1>
         <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow space-y-1">
-          <p>Пользователь: <strong>{username || state.profile.name}</strong></p>
-          <p>Подписка: <strong>{state.profile.subscription}</strong></p>
+          <p>
+            Пользователь: <strong>{username || state.profile.name}</strong>
+          </p>
+          <p>
+            Подписка: <strong>{state.profile.subscription}</strong>
+          </p>
         </div>
-        <nav className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-          <NavLink to="profile" className={linkClass}>Профиль</NavLink>
-          <NavLink to="data" className={linkClass}>Мои данные</NavLink>
-          <NavLink to="support" className={linkClass}>Поддержка</NavLink>
-          <NavLink to="notifications" className={linkClass}>Уведомления</NavLink>
+        <nav className="grid grid-cols-2 gap-2">
+          <NavLink to="profile" className={linkClass}>
+            Профиль
+          </NavLink>
+          <NavLink to="xui" className={linkClass}>
+            3x-ui
+          </NavLink>
         </nav>
         <Outlet />
       </div>

--- a/frontend/src/pages/XuiDashboard.tsx
+++ b/frontend/src/pages/XuiDashboard.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import PageHead from '../components/PageHead';
+import React, { useEffect, useState } from "react";
+import PageHead from "../components/PageHead";
 
 interface Inbound {
   id: number;
@@ -7,44 +7,189 @@ interface Inbound {
   enable?: boolean;
 }
 
+interface Server {
+  id: number;
+  name: string;
+  baseUrl: string;
+  username: string;
+  password: string;
+}
+
 const XuiDashboard: React.FC = () => {
+  const [servers, setServers] = useState<Server[]>([]);
+  const [selected, setSelected] = useState<number | null>(null);
   const [inbounds, setInbounds] = useState<Inbound[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [newServer, setNewServer] = useState({
+    name: "",
+    baseUrl: "",
+    username: "",
+    password: "",
+  });
 
   useEffect(() => {
+    fetch("/api/xui/servers")
+      .then((res) => res.json())
+      .then((data) => {
+        setServers(Array.isArray(data.servers) ? data.servers : []);
+      })
+      .catch((e) => setError(e.message));
+  }, []);
+
+  const fetchInbounds = (id: number) => {
     setLoading(true);
-    fetch('/api/xui/inbounds')
-      .then(res => {
-        if (!res.ok) throw new Error('Network error');
+    fetch(`/api/xui/inbounds/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Network error");
         return res.json();
       })
-      .then(data => {
+      .then((data) => {
+        setSelected(id);
         setInbounds(Array.isArray(data.inbounds) ? data.inbounds : []);
         setLoading(false);
       })
-      .catch(e => {
+      .catch((e) => {
         setError(e.message);
         setLoading(false);
       });
-  }, []);
+  };
+
+  const addServer = () => {
+    fetch("/api/xui/servers", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(newServer),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to add");
+        return res.json();
+      })
+      .then((data) => {
+        setServers((s) => [...s, { ...newServer, id: data.id }]);
+        setNewServer({ name: "", baseUrl: "", username: "", password: "" });
+      })
+      .catch((e) => setError(e.message));
+  };
+
+  const removeServer = (id: number) => {
+    fetch(`/api/xui/servers/${id}`, { method: "DELETE" })
+      .then(() => {
+        setServers((s) => s.filter((sr) => sr.id !== id));
+        if (selected === id) {
+          setSelected(null);
+          setInbounds([]);
+        }
+      })
+      .catch((e) => setError(e.message));
+  };
 
   return (
     <>
-      <PageHead title="3x-ui" description="Управление сервером" path="/xui" />
-      <div className="container mx-auto p-4 max-w-3xl space-y-4">
+      <PageHead
+        title="3x-ui"
+        description="Управление сервером"
+        path="/account/xui"
+      />
+      <div className="container mx-auto p-4 max-w-3xl space-y-6">
         <h1 className="text-2xl font-bold">3x-ui Dashboard</h1>
-        {loading && <p>Загрузка...</p>}
-        {error && <p className="text-red-500">{error}</p>}
-        <ul className="space-y-2">
-          {inbounds.map(inb => (
-            <li key={inb.id} className="border rounded p-2">
-              <div className="font-semibold">{inb.remark || inb.id}</div>
-              <div className="text-sm">{inb.enable ? 'Включен' : 'Выключен'}</div>
-            </li>
-          ))}
-          {inbounds.length === 0 && !loading && <li>Нет данных</li>}
-        </ul>
+
+        <div className="space-y-4">
+          <h2 className="text-xl font-semibold">Серверы</h2>
+          <ul className="space-y-2">
+            {servers.map((s) => (
+              <li
+                key={s.id}
+                className="border rounded p-2 flex justify-between items-center"
+              >
+                <div>
+                  <div className="font-semibold">{s.name}</div>
+                  <div className="text-sm text-gray-500">{s.baseUrl}</div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => fetchInbounds(s.id)}
+                    className="px-3 py-1 bg-blue-500 text-white rounded-md"
+                  >
+                    Просмотр
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => removeServer(s.id)}
+                    className="px-3 py-1 bg-red-500 text-white rounded-md"
+                  >
+                    Удалить
+                  </button>
+                </div>
+              </li>
+            ))}
+            {servers.length === 0 && <li>Нет серверов</li>}
+          </ul>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Добавить сервер</h2>
+          <input
+            className="w-full px-3 py-2 border rounded-md"
+            placeholder="Название"
+            value={newServer.name}
+            onChange={(e) =>
+              setNewServer({ ...newServer, name: e.target.value })
+            }
+          />
+          <input
+            className="w-full px-3 py-2 border rounded-md"
+            placeholder="URL"
+            value={newServer.baseUrl}
+            onChange={(e) =>
+              setNewServer({ ...newServer, baseUrl: e.target.value })
+            }
+          />
+          <input
+            className="w-full px-3 py-2 border rounded-md"
+            placeholder="Username"
+            value={newServer.username}
+            onChange={(e) =>
+              setNewServer({ ...newServer, username: e.target.value })
+            }
+          />
+          <input
+            type="password"
+            className="w-full px-3 py-2 border rounded-md"
+            placeholder="Password"
+            value={newServer.password}
+            onChange={(e) =>
+              setNewServer({ ...newServer, password: e.target.value })
+            }
+          />
+          <button
+            type="button"
+            onClick={addServer}
+            className="px-4 py-2 bg-green-500 text-white rounded-md"
+          >
+            Добавить
+          </button>
+        </div>
+
+        {selected && (
+          <div className="space-y-2">
+            <h2 className="text-xl font-semibold">Правила сервера</h2>
+            {loading && <p>Загрузка...</p>}
+            {error && <p className="text-red-500">{error}</p>}
+            <ul className="space-y-2">
+              {inbounds.map((inb) => (
+                <li key={inb.id} className="border rounded p-2">
+                  <div className="font-semibold">{inb.remark || inb.id}</div>
+                  <div className="text-sm">
+                    {inb.enable ? "Включен" : "Выключен"}
+                  </div>
+                </li>
+              ))}
+              {inbounds.length === 0 && !loading && <li>Нет данных</li>}
+            </ul>
+          </div>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- nest xui dashboard under account section
- remove unused account subpages from navigation
- allow editing list of x-ui servers in backend and dashboard

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c99fc8160832cb52a6f84a52d858d