### PR TITLE
Implement role-based auth with SQLite

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -7,6 +7,7 @@ PASSWORD=your_secure_password_here
 XUI_BASE_URL=https://xui.example.com
 XUI_USERNAME=admin
 XUI_PASSWORD=your_xui_password
+TOKEN_SECRET=change_this_secret
 
 # Опциональные переменные окружения
 PORT=3000

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -1,0 +1,17 @@
+const { verifyToken } = require('../utils/auth');
+
+function authMiddleware(roles = []) {
+  return (req, res, next) => {
+    const auth = req.get('Authorization') || '';
+    const token = auth.startsWith('Bearer ') ? auth.slice(7) : null;
+    const payload = verifyToken(token);
+    if (!payload) return res.status(401).json({ error: 'Unauthorized' });
+    if (roles.length && !roles.includes(payload.role)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    req.user = payload;
+    next();
+  };
+}
+
+module.exports = { authMiddleware };

--- a/backend/routes/authRouter.js
+++ b/backend/routes/authRouter.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const { verifyUser, generateToken } = require('../utils/auth');
+const router = express.Router();
+
+function initAuthRouter() {}
+
+router.post('/login', express.json(), (req, res) => {
+  const { username, password } = req.body || {};
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Missing credentials' });
+  }
+  const user = verifyUser(username, password);
+  if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+  const token = generateToken({ username: user.username, role: user.role });
+  res.json({ token, role: user.role });
+});
+
+module.exports = { router, initAuthRouter };

--- a/backend/server.js
+++ b/backend/server.js
@@ -17,6 +17,9 @@ const {
   initCacheRouter
 } = require('./routes/cacheRouter');
 const { router: xuiRouter, initXuiRouter } = require('./routes/xuiRouter');
+const { router: authRouter, initAuthRouter } = require('./routes/authRouter');
+const { initAuth } = require('./utils/auth');
+const { authMiddleware } = require('./middleware/authMiddleware');
 const { validateOptionalVars } = require('./config/validation');
 const { createLogger } = require('./config/logger');
 const { createCorsOptions } = require('./middleware/cors');
@@ -84,6 +87,9 @@ try {
   throw new Error(`Environment variables validation failed: ${error.message}`);
 }
 
+initAuth();
+initAuthRouter();
+
 const port = optionalVars.PORT;
 
 // --- КОНФИГУРАЦИЯ СЕРВЕРОВ ---
@@ -136,10 +142,11 @@ initXuiRouter({
   logger
 });
 // --- ПОДКЛЮЧЕНИЕ РОУТЕРОВ ---
+app.use('/api', authRouter);
 app.use('/api', statusRouter);
 app.use('/api', healthRouter);
 app.use('/api', cacheRouter);
-app.use('/api', xuiRouter);
+app.use('/api', authMiddleware(['admin']), xuiRouter);
 
 // --- FRONTEND LOGGING ENDPOINT ---
 const frontendLogger = createLogger(

--- a/backend/utils/auth.js
+++ b/backend/utils/auth.js
@@ -1,0 +1,47 @@
+const { createHash, createHmac } = require('crypto');
+const { init, query, run } = require('./database');
+
+const SECRET = process.env.TOKEN_SECRET || 'change_this_secret';
+
+function hashPassword(password) {
+  return createHash('sha256').update(password).digest('hex');
+}
+
+function initAuth() {
+  init();
+  const adminUser = process.env.USERNAME || 'admin';
+  const adminPass = process.env.PASSWORD || 'admin';
+  const rows = query(`SELECT id FROM users WHERE username='${adminUser}'`);
+  if (rows.length === 0) {
+    run(`INSERT INTO users (username, password, role) VALUES ('${adminUser}','${hashPassword(adminPass)}','admin')`);
+  }
+}
+
+function verifyUser(username, password) {
+  const rows = query(`SELECT id, username, password, role FROM users WHERE username='${username}'`);
+  if (rows.length === 0) return null;
+  const user = rows[0];
+  if (user.password !== hashPassword(password)) return null;
+  return user;
+}
+
+function generateToken(payload) {
+  const data = { ...payload, exp: Date.now() + 24 * 60 * 60 * 1000 };
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(data)).toString('base64url');
+  const signature = createHmac('sha256', SECRET).update(`${header}.${body}`).digest('base64url');
+  return `${header}.${body}.${signature}`;
+}
+
+function verifyToken(token) {
+  if (!token) return null;
+  const [header, body, signature] = token.split('.');
+  if (!signature) return null;
+  const expected = createHmac('sha256', SECRET).update(`${header}.${body}`).digest('base64url');
+  if (signature !== expected) return null;
+  const data = JSON.parse(Buffer.from(body, 'base64url').toString());
+  if (data.exp < Date.now()) return null;
+  return data;
+}
+
+module.exports = { initAuth, verifyUser, generateToken, verifyToken };

--- a/backend/utils/database.js
+++ b/backend/utils/database.js
@@ -1,0 +1,30 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const DB_PATH = path.join(__dirname, 'data.sqlite');
+
+function run(sql) {
+  const result = spawnSync('sqlite3', [DB_PATH, sql], { encoding: 'utf8' });
+  if (result.error) throw result.error;
+  if (result.stderr) throw new Error(result.stderr.trim());
+  return result.stdout.trim();
+}
+
+function query(sql) {
+  const result = spawnSync('sqlite3', ['-json', DB_PATH, sql], { encoding: 'utf8' });
+  if (result.error) throw result.error;
+  if (result.stderr) throw new Error(result.stderr.trim());
+  const out = result.stdout.trim();
+  return out ? JSON.parse(out) : [];
+}
+
+function init() {
+  if (!fs.existsSync(DB_PATH)) {
+    run(
+      'CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT, role TEXT);'
+    );
+  }
+}
+
+module.exports = { init, run, query, DB_PATH };

--- a/docs/API_ROUTES.md
+++ b/docs/API_ROUTES.md
@@ -25,6 +25,11 @@
 - **Тело запроса**: `{ level?: string, message: string, ...meta }`
 - **Ответ**: `204 No Content` при успешном приёме.
 
+### `POST /api/login`
+Авторизация пользователя и получение токена.
+- **Тело запроса**: `{ username: string, password: string }`
+- **Ответ**: `{ token: string, role: string }`
+
 ### `GET /api/xui/inbounds`
 Возвращает список инбаундов из 3x-ui.
 - **Ответ**: `{ inbounds: Inbound[] }`

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -26,6 +26,7 @@
 | `RATE_LIMIT_WINDOW_MS` | Окно ограничения запросов (мс) |
 | `RATE_LIMIT_MAX_REQUESTS` | Максимум запросов в окне |
 | `LOGIN_TIMEOUT` | Таймаут авторизации (мс) |
+| `TOKEN_SECRET` | Секрет для подписи токенов |
 | `PING_TIMEOUT` | Таймаут пинга серверов (мс) |
 | `FETCH_TIMEOUT` | Таймаут HTTP-запросов (мс) |
 | `LOG_FILE_MAX_SIZE` | Максимальный размер файла логов |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import Faq from "./pages/Faq";
 import Account from "./pages/Account";
 import ProfilePage from "./pages/ProfilePage";
 import XuiDashboard from "./pages/XuiDashboard";
+import LoginPage from "./pages/LoginPage";
 import TelegramFab from "./components/TelegramFab";
 import { logFrontend } from "./utils/logger";
 import { ThemeProvider } from "./context/ThemeContext";
@@ -53,6 +54,7 @@ const App: React.FC = () => (
                 <Route path="/" element={<Home />} />
                 <Route path="/servers" element={<Servers />} />
                 <Route path="/faq" element={<Faq />} />
+                <Route path="/login" element={<LoginPage />} />
                 <Route path="/account" element={<Account />}>
                   <Route index element={<ProfilePage />} />
                   <Route path="profile" element={<ProfilePage />} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -41,8 +41,8 @@ const Header: React.FC = () => {
         ariaLabel: "FAQ",
       },
       {
-        href: "/account",
-        label: username || "Аккаунт",
+        href: username ? "/account" : "/login",
+        label: username || "Войти",
         icon: <FaUser />,
         ariaLabel: "Аккаунт",
       },

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -13,7 +13,7 @@ const linkClass = ({ isActive }: { isActive: boolean }) =>
 
 const Account: React.FC = () => {
   const { state } = useAccount();
-  const { username } = useUser();
+  const { username, role } = useUser();
 
   return (
     <>
@@ -36,6 +36,11 @@ const Account: React.FC = () => {
           <NavLink to="profile" className={linkClass}>
             Профиль
           </NavLink>
+          {role === 'admin' && (
+            <NavLink to="xui" className={linkClass}>
+              3x-ui
+            </NavLink>
+          )}
         </nav>
         <Outlet />
       </div>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useUser } from '../context/UserContext';
+import PageHead from '../components/PageHead';
+
+const LoginPage: React.FC = () => {
+  const { login } = useUser();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await login(username, password);
+      navigate('/account');
+    } catch (err) {
+      setError('Ошибка авторизации');
+    }
+  };
+
+  return (
+    <>
+      <PageHead title="Вход" description="Авторизация" path="/login" />
+      <div className="container mx-auto p-4 max-w-sm space-y-4">
+        <h1 className="text-2xl font-bold">Вход</h1>
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <input
+            className="w-full px-3 py-2 border rounded-md"
+            placeholder="Имя"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+          />
+          <input
+            type="password"
+            className="w-full px-3 py-2 border rounded-md"
+            placeholder="Пароль"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded-md">
+            Войти
+          </button>
+        </form>
+      </div>
+    </>
+  );
+};
+
+export default LoginPage;


### PR DESCRIPTION
## Summary
- add local SQLite utility and auth helpers
- create login router and middleware
- secure XUI routes for admins only
- implement token-based login on frontend
- show admin-only link in account page
- document new API endpoint and TOKEN_SECRET env var

## Testing
- `cd backend && npm run validate` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: missing script 'test')*
- `cd frontend && npm run validate` *(fails: missing script 'validate')*
- `npm run test` *(fails: missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_687ca2c0e3a4832cafda0c0f04ab6d33