### PR TITLE
Fix auth system and tests

### DIFF
--- a/backend/routes/authRouter.js
+++ b/backend/routes/authRouter.js
@@ -1,5 +1,6 @@
 const express = require('express');
-const { verifyUser, generateToken } = require('../utils/auth');
+const { verifyUser, registerUser, generateToken } = require('../utils/auth');
+const { authMiddleware } = require('../middleware/authMiddleware');
 const router = express.Router();
 
 let logger;
@@ -21,6 +22,24 @@ router.post('/login', express.json(), (req, res) => {
   const token = generateToken({ username: user.username, role: user.role });
   logger && logger.info && logger.info('User logged in', { username: user.username });
   res.json({ token, role: user.role });
+});
+
+router.post('/register', express.json(), (req, res) => {
+  const { username, password } = req.body || {};
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Missing credentials' });
+  }
+  const user = registerUser(username, password);
+  if (!user) {
+    return res.status(409).json({ error: 'User already exists' });
+  }
+  logger && logger.info && logger.info('User registered', { username });
+  const token = generateToken({ username: user.username, role: user.role });
+  res.status(201).json({ token, role: user.role });
+});
+
+router.get('/me', authMiddleware(), (req, res) => {
+  res.json({ username: req.user.username, role: req.user.role });
 });
 
 module.exports = { router, initAuthRouter };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "npm run start --workspace backend",
     "dev": "npm run dev --workspace backend",
     "validate": "npm run validate --workspace backend && npm run validate --workspace frontend || true",
-    "test": "npm --workspaces --if-present run test",
+    "test": "npm --workspaces --if-present run test && npm run test:root",
     "test:root": "c8 --reporter=text --reporter=lcov --include=backend/** node --test tests",
     "build": "npm run build:css && npm run build:js",
     "build:css": "npx tailwindcss -i ./frontend/src/input.css -o ./frontend/dist/output.css --minify",

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const usersFile = path.resolve(__dirname, '../data/users.json');
+
+test('initAuth creates admin user and verifies token', () => {
+  if (fs.existsSync(usersFile)) fs.unlinkSync(usersFile);
+  process.env.USERNAME = 'admin';
+  process.env.PASSWORD = 'secret';
+  const auth = require('../backend/utils/auth');
+  auth.initAuth();
+  const user = auth.verifyUser('admin', 'secret');
+  assert.ok(user);
+  const token = auth.generateToken({ username: user.username, role: user.role });
+  const payload = auth.verifyToken(token);
+  assert.strictEqual(payload.username, 'admin');
+});
+
+test('registerUser adds new user', () => {
+  const auth = require('../backend/utils/auth');
+  const user = auth.registerUser('newuser', 'pass123');
+  assert.ok(user);
+  const again = auth.registerUser('newuser', 'pass123');
+  assert.strictEqual(again, null);
+});

--- a/tests/vpnService.test.js
+++ b/tests/vpnService.test.js
@@ -25,7 +25,7 @@ test('sleep waits at least the specified time', async () => {
 });
 
 test('fetchDataWithRetry and getCookie', async () => {
-  const ping = require('../backend/node_modules/ping');
+  const ping = require('ping');
   ping.promise.probe = async () => ({ alive: true, time: 10 });
   delete require.cache[require.resolve('../backend/vpnService')];
 
@@ -74,7 +74,7 @@ test('fetchDataWithRetry and getCookie', async () => {
 });
 
 test('pingServer returns result', async () => {
-  const ping = require('../backend/node_modules/ping');
+  const ping = require('ping');
   ping.promise.probe = async () => ({ alive: true, time: 5 });
   delete require.cache[require.resolve('../backend/vpnService')];
   const { pingServer } = require('../backend/vpnService');
@@ -83,7 +83,7 @@ test('pingServer returns result', async () => {
 });
 
 test('fetchDataWithRetry handles http error', async () => {
-  const ping = require('../backend/node_modules/ping');
+  const ping = require('ping');
   ping.promise.probe = async () => ({ alive: false, time: -1 });
   delete require.cache[require.resolve('../backend/vpnService')];
   global.fetch = async () => ({ ok: false, status: 500, statusText: 'Server error', text: async () => 'err' });
@@ -92,7 +92,7 @@ test('fetchDataWithRetry handles http error', async () => {
 });
 
 test('getServerStatus handles failure', async () => {
-  const ping = require('../backend/node_modules/ping');
+  const ping = require('ping');
   ping.promise.probe = async () => { throw new Error('fail'); };
   delete require.cache[require.resolve('../backend/vpnService')];
   global.fetch = async () => { throw new Error('network'); };


### PR DESCRIPTION
## Summary
- implement simple user storage and registration
- initialize routers & caches in the API server
- add `/register` and `/me` endpoints
- update test script and add auth tests
- fix ping module path in vpnService tests

## Testing
- `npm run validate && npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cc5a7cdf8832c82ab7118d829fb7c