### PR TITLE
Remove secrets from PM2 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 cd backend
 npm install
 cp env.example .env
-# настройте .env
+# внесите реальные значения в .env (API URL, TELEGRAM_BOT_TOKEN, JWT_SECRET и др.)
 # подробнее о переменных смотрите в [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md)
 npm run dev      # запуск в режиме разработки
 npm start        # запуск в продакшн

--- a/backend/env.example
+++ b/backend/env.example
@@ -33,4 +33,9 @@ FETCH_TIMEOUT=10000
 
 # Настройки логирования
 LOG_FILE_MAX_SIZE=10485760
-LOG_FILE_MAX_FILES=5 
+LOG_FILE_MAX_FILES=5
+
+# Дополнительные секреты
+JWT_SECRET=your_jwt_secret
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+TELEGRAM_BOT_USERNAME=your_telegram_bot_username

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -11,6 +11,9 @@
 | `FINLAND_API_URL` | URL сервера в Финляндии |
 | `USERNAME` | Имя пользователя для админ-доступа |
 | `PASSWORD` | Пароль для админ-доступа |
+| `JWT_SECRET` | Секретный ключ для JWT |
+| `TELEGRAM_BOT_TOKEN` | Токен Telegram-бота |
+| `TELEGRAM_BOT_USERNAME` | Имя Telegram-бота |
 
 ## Опциональные параметры
 

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -6,38 +6,38 @@ module.exports = {
       cwd: './',
       node_args: '--enable-source-maps',
       env: {
-        NODE_ENV: 'production',
-        PORT: 3000,
-        LOG_LEVEL: 'info',
+        NODE_ENV: process.env.NODE_ENV || 'production',
+        PORT: process.env.PORT || 3000,
+        LOG_LEVEL: process.env.LOG_LEVEL || 'info',
 
-        GERMANY_API_URL: 'https://rvpn.rox-net.ru:33000/Y2u3mwGrRKU3aeh',
-        USA_API_URL: 'https://rvpn2.rox-net.ru:33000/Y2u3mwGrRKU3aeh',
-        FINLAND_API_URL: 'https://rvpn3.rox-net.ru:33000/Y2u3mwGrRKU3aeh',
-        USERNAME: 'aw775hats0on',
-        PASSWORD: 'fbhWjpZWw9a6TmaeRKP4YV98K8Rcmm3BSPHs1ujXGkJEK6bYC1IkBuK0hECiLtHV',
+        GERMANY_API_URL: process.env.GERMANY_API_URL,
+        USA_API_URL: process.env.USA_API_URL,
+        FINLAND_API_URL: process.env.FINLAND_API_URL,
+        USERNAME: process.env.USERNAME,
+        PASSWORD: process.env.PASSWORD,
 
-        TELEGRAM_BOT_TOKEN: '7779535899:AAFjDu4elpu9hWKsywbEIO9oL7zIWK1K5nY',
-        TELEGRAM_BOT_USERNAME: 'rx_test_ru_bot',
+        TELEGRAM_BOT_TOKEN: process.env.TELEGRAM_BOT_TOKEN,
+        TELEGRAM_BOT_USERNAME: process.env.TELEGRAM_BOT_USERNAME,
 
-        JWT_SECRET: 'BJZGPmQHDuV4TgZwuFuaoB6oyQc5W4AB9CS4j80yfcrd',
+        JWT_SECRET: process.env.JWT_SECRET,
 
-        PINGHOST1: '103.7.55.165',
-        PINGHOST2: '167.224.64.248',
-        PINGHOST3: '46.8.71.6',
+        PINGHOST1: process.env.PINGHOST1,
+        PINGHOST2: process.env.PINGHOST2,
+        PINGHOST3: process.env.PINGHOST3,
 
-        ALLOWED_ORIGIN: 'https://rx-test.ru',
+        ALLOWED_ORIGIN: process.env.ALLOWED_ORIGIN,
 
-        CACHE_DURATION: 60000,
-        COOKIE_CACHE_DURATION: 3300000,
+        CACHE_DURATION: process.env.CACHE_DURATION || 60000,
+        COOKIE_CACHE_DURATION: process.env.COOKIE_CACHE_DURATION || 3300000,
 
-        RATE_LIMIT_WINDOW_MS: 60000,
-        RATE_LIMIT_MAX_REQUESTS: 3000,
+        RATE_LIMIT_WINDOW_MS: process.env.RATE_LIMIT_WINDOW_MS || 60000,
+        RATE_LIMIT_MAX_REQUESTS: process.env.RATE_LIMIT_MAX_REQUESTS || 3000,
 
-        LOGIN_TIMEOUT: 10000,
-        PING_TIMEOUT: 5000,
-        FETCH_TIMEOUT: 10000,
+        LOGIN_TIMEOUT: process.env.LOGIN_TIMEOUT || 10000,
+        PING_TIMEOUT: process.env.PING_TIMEOUT || 5000,
+        FETCH_TIMEOUT: process.env.FETCH_TIMEOUT || 10000,
 
-        LOG_FILE_MAX_SIZE: 10485760
+        LOG_FILE_MAX_SIZE: process.env.LOG_FILE_MAX_SIZE || 10485760
       }
     }
   ]


### PR DESCRIPTION
## Summary
- reference environment variables in `ecosystem.config.js`
- expand env example and docs with Telegram/JWT variables
- clarify README to fill in secret values

## Testing
- `npm install`
- `npm run install:backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687db415f418832ca4b2520c5f4103b5