### PR TITLE
Fix duplicate admin router setup

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -100,7 +100,6 @@ initCacheRouter({ SERVER_CONFIGS, statusCache, cookieCache: cookieCache.cache, l
 app.use('/api', statusRouter)
 app.use('/api', healthRouter)
 app.use('/api', cacheRouter)
-app.use('/api', adminRouter)
 import authRouter from './src/api/auth.js'
 app.use('/api/auth', authRouter)
 import adminRouter from './src/api/admin.js'


### PR DESCRIPTION
## Summary
- remove redundant call to admin router at `/api`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687db6655880832c91aef88268b3317a