### PR TITLE
Use env for WebSocket URL

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -35,6 +35,9 @@ FETCH_TIMEOUT=10000
 LOG_FILE_MAX_SIZE=10485760
 LOG_FILE_MAX_FILES=5
 
+# Frontend settings
+VITE_WS_URL=wss://rx-test.ru
+
 # Дополнительные секреты
 JWT_SECRET=your_jwt_secret
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -33,5 +33,6 @@
 | `FETCH_TIMEOUT` | Таймаут HTTP-запросов (мс) |
 | `LOG_FILE_MAX_SIZE` | Максимальный размер файла логов |
 | `LOG_FILE_MAX_FILES` | Количество файлов логов |
+| `VITE_WS_URL` | Базовый URL WebSocket для фронтенда |
 
 Дополнительные детали смотрите в примере `backend/env.example`.

--- a/frontend/src/pages/admin/learning-insights.tsx
+++ b/frontend/src/pages/admin/learning-insights.tsx
@@ -12,7 +12,8 @@ export default function LearningInsightsDashboard() {
   }, [navigate]);
 
   useEffect(() => {
-    const ws = new WebSocket("wss://rx-test.ru/ws/insights");
+    const baseUrl = import.meta.env.VITE_WS_URL || "wss://rx-test.ru";
+    const ws = new WebSocket(`${baseUrl}/ws/insights`);
     ws.onmessage = (event) => {
       const data = JSON.parse(event.data);
       setLogs((prev) => [data, ...prev.slice(0, 100)]);


### PR DESCRIPTION
## Summary
- inject WebSocket URL from environment in learning insights page
- document `VITE_WS_URL` variable
- add example value in backend env template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dca9eedf4832ca44e143aa8a67535