### PR TITLE
Make frontend update path configurable

### DIFF
--- a/update-frontend.sh
+++ b/update-frontend.sh
@@ -1,25 +1,30 @@
 #!/bin/bash
 
 # Скрипт для обновления фронтенда ROX VPN
+# Usage: PROJECT_PATH=/path/to/newFrontLanding ./update-frontend.sh
+#    или: ./update-frontend.sh /path/to/newFrontLanding
+# Если путь не указан, используется директория расположения скрипта.
 set -e
-chown rx_test_ru_usr:rx_test_ru_usr -R /var/www/rx_test_ru_usr/data/www/rx-test.ru/newFrontLanding/
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_PATH="${PROJECT_PATH:-${1:-$SCRIPT_DIR}}"
+
+chown rx_test_ru_usr:rx_test_ru_usr -R "$PROJECT_PATH"
 echo "🔄 Обновление фронтенда ROX VPN..."
 
 # Переходим в директорию фронтенда
-cd frontend
+cd "$PROJECT_PATH/frontend"
 
 echo "📦 Сборка фронтенда..."
 npm run build
 
 echo "✅ Фронтенд собран успешно"
 
-# Возвращаемся в корневую директорию
-cd ..
-cd backend
+# Переходим в директорию backend
+cd "$PROJECT_PATH/backend"
 echo "🔄 Перезапуск сервера..."
 pm2 restart rox-vpn
 
 echo "✅ Сервер перезапущен"
-cd ..
 echo "🎉 Обновление завершено!"
-echo "🌐 Сайт доступен по адресу: http://localhost:3000" 
+echo "🌐 Сайт доступен по адресу: http://localhost:3000"


### PR DESCRIPTION
## Summary
- allow passing project path to `update-frontend.sh`
- document usage for PROJECT_PATH at the top of the script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e09d5219c832cbd4947a0bc6891c8